### PR TITLE
Fix incorrect drawing on ARM systems

### DIFF
--- a/src/StavePosition.h
+++ b/src/StavePosition.h
@@ -33,6 +33,7 @@
 #include "Chord.h"
 
 #include <stdio.h>
+#include <stdint.h>
 
 typedef  struct {
     int pianoNote;   // 1 is Middle C, 2 is D
@@ -147,7 +148,7 @@ public:
 
 private:
     // fixme TODO This could be improved as the calculations could a done in the constructor
-    int m_staveIndex;    // 0 central line, 5 = top line, -5 the bottom line,
+    int8_t m_staveIndex;    // 0 central line, 5 = top line, -5 the bottom line,
     int m_accidental;         // 0 = none, 1=sharp, -1 =flat, 2=natural
     float m_offsetY;
     whichPart_t m_hand;


### PR DESCRIPTION
Unfortunately I do not remember the rationale of this patch.

It fix the incorrect drawing of music sheet at least on Raspberry PI3. Probably will work with other ARM devices.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>