### PR TITLE
Colour-Coded Notes (Kory Code + Toggle Glue)

### DIFF
--- a/src/Draw.cpp
+++ b/src/Draw.cpp
@@ -578,13 +578,13 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
                     case 0: //note::PitchLabel::C:
                         colour = CColour(1.0, 0.0, 0.0); //Red
                       break;
-                    case 1: //note::PitchLabel::CS:
+                    case 1: //note::PitchLabel::C♯:
                         colour = CColour(1.0, 0.25, 0.0); //Red
                       break;
                     case 2: //note::PitchLabel::D:
                         colour = CColour(1.0, 0.5, 0.0); //Orange
                       break;
-                    case 3: //note::PitchLabel::DS:
+                    case 3: //note::PitchLabel::D♯:
                         colour = CColour(1.0, 0.75, 0.0); //Orange
                       break;
                     case 4: //note::PitchLabel::E:
@@ -593,19 +593,19 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
                     case 5: //note::PitchLabel::F:
                         colour = CColour(0.0, 1.0, 0.0); //Green
                       break;
-                    case 6: //note::PitchLabel::FS:
+                    case 6: //note::PitchLabel::F♯:
                         colour = CColour(0.0, 0.5, 0.5); //Green
                       break;
                     case 7: //note::PitchLabel::G:
                         colour = CColour(0.0, 0.0, 1.0); //Blue
                       break;
-                    case 8: //note::PitchLabel::GS:
+                    case 8: //note::PitchLabel::G♯:
                         colour = CColour(0.290, 0.0, 0.903); //Blue
                       break;
                     case 9: //note::PitchLabel::A:
                         colour = CColour(0.580, 0.0, 0.827); //Dark Violet #9400D3
                       break;
-                    case 10: //note::PitchLabel::AS:
+                    case 10: //note::PitchLabel::A♯:
                         colour = CColour(0.790, 0.0, 0.903); //Dark Violet #9400D3
                       break;
                     case 11: //note::PitchLabel::B:
@@ -613,7 +613,6 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
                       break;
                 }
             }
-
 #endif
             drColour(colour);
             glBegin(GL_POLYGON);

--- a/src/Draw.cpp
+++ b/src/Draw.cpp
@@ -566,11 +566,11 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
                 playable = false;
             }
             drawStaveExtentsion(symbol, x, 16, playable);
-#if 1
+
 	    // See forum post at link below from PianoBooster forum user Kory.
 	    // http://piano-booster.2625608.n2.nabble.com/Pianobooster-port-to-arm-linux-or-Android-td7572459.html
 	    // http://piano-booster.2625608.n2.nabble.com/Pianobooster-port-to-arm-linux-or-Android-td7572459.html#a7572676
-            if (colour == Cfg::noteColour()) //KORY added
+            if (m_settings->colouredNotes() && colour == Cfg::noteColour()) //KORY added
             {
                 int note = symbol.getNote() % MIDI_OCTAVE;
                 switch (note)
@@ -613,7 +613,7 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
                       break;
                 }
             }
-#endif
+
             drColour(colour);
             glBegin(GL_POLYGON);
                 glVertex2f(-7.0 + x,  2.0 + y); // 1

--- a/src/Draw.cpp
+++ b/src/Draw.cpp
@@ -566,6 +566,55 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
                 playable = false;
             }
             drawStaveExtentsion(symbol, x, 16, playable);
+#if 1
+	    // See forum post at link below from PianoBooster forum user Kory.
+	    // http://piano-booster.2625608.n2.nabble.com/Pianobooster-port-to-arm-linux-or-Android-td7572459.html
+	    // http://piano-booster.2625608.n2.nabble.com/Pianobooster-port-to-arm-linux-or-Android-td7572459.html#a7572676
+            if (colour == Cfg::noteColour()) //KORY added
+            {
+                int note = symbol.getNote() % MIDI_OCTAVE;
+                switch (note)
+                {
+                    case 0: //note::PitchLabel::C:
+                        colour = CColour(1.0, 0.0, 0.0); //Red
+                      break;
+                    case 1: //note::PitchLabel::CS:
+                        colour = CColour(1.0, 0.25, 0.0); //Red
+                      break;
+                    case 2: //note::PitchLabel::D:
+                        colour = CColour(1.0, 0.5, 0.0); //Orange
+                      break;
+                    case 3: //note::PitchLabel::DS:
+                        colour = CColour(1.0, 0.75, 0.0); //Orange
+                      break;
+                    case 4: //note::PitchLabel::E:
+                        colour = CColour(1.0, 1.0, 0.0); //Yellow
+                      break;
+                    case 5: //note::PitchLabel::F:
+                        colour = CColour(0.0, 1.0, 0.0); //Green
+                      break;
+                    case 6: //note::PitchLabel::FS:
+                        colour = CColour(0.0, 0.5, 0.5); //Green
+                      break;
+                    case 7: //note::PitchLabel::G:
+                        colour = CColour(0.0, 0.0, 1.0); //Blue
+                      break;
+                    case 8: //note::PitchLabel::GS:
+                        colour = CColour(0.290, 0.0, 0.903); //Blue
+                      break;
+                    case 9: //note::PitchLabel::A:
+                        colour = CColour(0.580, 0.0, 0.827); //Dark Violet #9400D3
+                      break;
+                    case 10: //note::PitchLabel::AS:
+                        colour = CColour(0.790, 0.0, 0.903); //Dark Violet #9400D3
+                      break;
+                    case 11: //note::PitchLabel::B:
+                        colour = CColour(1.0, 0.0, 1.0); //Magenta
+                      break;
+                }
+            }
+
+#endif
             drColour(colour);
             glBegin(GL_POLYGON);
                 glVertex2f(-7.0 + x,  2.0 + y); // 1

--- a/src/QtWindow.cpp
+++ b/src/QtWindow.cpp
@@ -396,6 +396,15 @@ void QtWindow::createActions()
     }
     connect(m_viewPianoKeyboard, SIGNAL(triggered()), this, SLOT(onViewPianoKeyboard()));
 
+    m_colouredNotes = new QAction(tr("Colour Coded Notes"), this);
+    m_colouredNotes->setToolTip(tr("Colour Code Notes in Score"));
+    m_colouredNotes->setCheckable(true);
+    m_colouredNotes->setChecked(false);
+    if (m_settings->value("View/ColouredNotes").toString()=="on"){
+        m_colouredNotes->setChecked(true);
+    }
+    connect(m_colouredNotes, SIGNAL(triggered()), this, SLOT(onColouredNotes()));
+
     m_setupPreferencesAct = new QAction(tr("&Preferences ..."), this);
     m_setupPreferencesAct->setToolTip(tr("Settings"));
     m_setupPreferencesAct->setShortcut(tr("Ctrl+P"));
@@ -456,6 +465,7 @@ void QtWindow::createMenus()
     m_viewMenu->addAction(m_sidePanelStateAct);
     m_viewMenu->addAction(m_fullScreenStateAct);
     m_viewMenu->addAction(m_viewPianoKeyboard);
+    m_viewMenu->addAction(m_colouredNotes);
 
     m_songMenu = menuBar()->addMenu(tr("&Song"));
     m_songMenu->setToolTipsVisible(true);

--- a/src/QtWindow.h
+++ b/src/QtWindow.h
@@ -130,6 +130,10 @@ private slots:
             showNormal();
     }
 
+    void onColouredNotes () {
+      m_settings->colouredNotes(m_colouredNotes->isChecked());
+    }
+
     void enableFollowTempo()
     {
         CTempo::enableFollowTempo(Cfg::experimentalTempo);
@@ -214,6 +218,7 @@ private:
     QAction *m_setupKeyboardAct;
     QAction *m_sidePanelStateAct;
     QAction *m_viewPianoKeyboard;
+    QAction *m_colouredNotes;
     QAction *m_fullScreenStateAct;
     QAction *m_setupPreferencesAct;
     QAction *m_songDetailsAct;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -66,6 +66,7 @@ CSettings::CSettings(QtWindow *mainWindow) : QSettings(CSettings::IniFormat, CSe
     m_advancedMode = false;
     m_pianistActive = false;
     m_noteNamesEnabled = value("Score/NoteNames", true ).toBool();
+    m_colouredNotes = value("Score/ColouredNotes", true ).toBool();
     m_tutorPagesEnabled = value("Tutor/TutorPages", true ).toBool();
     CNotation::setCourtesyAccidentals(value("Score/CourtesyAccidentals", false ).toBool());
     m_followThroughErrorsEnabled = value("Score/FollowThroughErrors", false ).toBool();
@@ -101,6 +102,11 @@ void CSettings::init(CSong* song, GuiSidePanel* sidePanel, GuiTopBar* topBar)
 void CSettings::setNoteNamesEnabled(bool value) {
     m_noteNamesEnabled = value;
     setValue("Score/NoteNames", value );
+}
+
+void CSettings::setColouredNotes(bool value) {
+    m_colouredNotes = value;
+    setValue("Score/ColouredNotes", value );
 }
 
 void CSettings::setTutorPagesEnabled(bool value) {

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -47,7 +47,7 @@ public:
 
     void init(CSong* song, GuiSidePanel* sidePanel, GuiTopBar* topBar);
 
-    /// returns true if the users wants to see the note names
+    /// returns true if the user wants to see the note names
     bool isNoteNamesEnabled() { return m_noteNamesEnabled; }
     bool displayCourtesyAccidentals() { return CNotation::displayCourtesyAccidentals(); }
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -56,15 +56,25 @@ public:
 
     /// Saves in the .ini file whether the user wants to show the note names
     void setNoteNamesEnabled(bool value);
+    void setColouredNotes(bool value);
     void setTutorPagesEnabled(bool value);
     void setFollowThroughErrorsEnabled(bool value);
 
     void setCourtesyAccidentals(bool value);
     void setAdvancedMode(bool value) { m_advancedMode = value;}
 
-    /// returns true if the users wants to see the note names
+    /// returns true if the user wants to see the note names
     bool showNoteNames(){
         return m_noteNamesEnabled;
+    }
+
+    /// returns true if the user wants to see colour-coded notes
+    bool colouredNotes(){
+        return m_colouredNotes;
+    }
+
+    void colouredNotes(bool b){
+        m_colouredNotes = b;
     }
 
     /// returns true if the user wants Follow Skill to ignore errors
@@ -149,6 +159,7 @@ private:
     GuiSidePanel* m_guiSidePanel;
     GuiTopBar* m_guiTopBar;
     bool m_noteNamesEnabled;
+    bool m_colouredNotes;
     bool m_tutorPagesEnabled;
     bool m_advancedMode;
     bool m_followThroughErrorsEnabled;


### PR DESCRIPTION
This adds a user-configurable option to allow colour-coded notes.

It could be improved by:
- making the keys on the keyboard widget match the colours
- making the displayed notes change colour immediately, not just as new ones scroll into view
- making the colours table-driven instead of a big switch statement, and allowing the table to be configured