### PR TITLE
Allow verbose makefiles on request

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Cmake File for Piano Booster
 # for the debug build type cmake -DCMAKE_BUILD_TYPE=Debug
 SET(CMAKE_BUILD_TYPE Release)
-SET(CMAKE_VERBOSE_MAKEFILE OFF)
 
 option(USE_FTGL "build with ftgl" ON)
 


### PR DESCRIPTION
Default for this variable is FALSE already. Unconditional SET() prevents this
standard CMake feature from being set normally from the command line.

https://cmake.org/cmake/help/latest/variable/CMAKE_VERBOSE_MAKEFILE.html

Debian wants to have verbose build logs for eventual troubleshooting purposes.
Regular log scans are used to check if packages actually use the distro's default build flags.

https://www.debian.org/doc/debian-policy/ch-source.html#main-building-script-debian-rules
https://qa.debian.org/bls/packages/p/pianobooster.html